### PR TITLE
Some suggestions related to the deprecation warnings & tests

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -339,7 +339,7 @@ def pagerank_numpy(G, alpha=0.85, personalization=None, weight="weight", danglin
        http://dbpubs.stanford.edu:8090/pub/showDoc.Fulltext?lang=en&doc=1999-66&format=pdf
     """
     msg = "networkx.pagerank_numpy will be deprecated in NetworkX 3.0, use networkx.pagerank instead."
-    warn(msg, DeprecationWarning)
+    warn(msg, DeprecationWarning, stacklevel=2)
     import numpy as np
 
     if len(G) == 0:
@@ -449,7 +449,7 @@ def pagerank_scipy(
        http://dbpubs.stanford.edu:8090/pub/showDoc.Fulltext?lang=en&doc=1999-66&format=pdf
     """
     msg = "networkx.pagerank_scipy will be deprecated in NetworkX 3.0, use networkx.pagerank instead."
-    warn(msg, DeprecationWarning)
+    warn(msg, DeprecationWarning, stacklevel=2)
     import numpy as np
     import scipy.sparse
 

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -243,3 +243,17 @@ class TestPageRankScipy(TestPageRank):
     def test_empty_scipy(self):
         G = networkx.Graph()
         assert networkx.pagerank_scipy(G) == {}
+
+
+@pytest.mark.parametrize(
+    "pagerank_alg",
+    (networkx.pagerank_numpy, networkx.pagerank_scipy),
+)
+def test_deprecation_warnings(pagerank_alg):
+    """Make sure deprecation warnings are raised.
+
+    To be removed when deprecations expire.
+    """
+    G = networkx.DiGraph(networkx.path_graph(4))
+    with pytest.warns(DeprecationWarning):
+        pr = pagerank_alg(G, alpha=0.9)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -102,7 +102,9 @@ class TestPageRank:
         for n in G:
             assert almost_equal(p[n], answer[n], places=4)
 
-    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    @pytest.mark.parametrize(
+        "alg", (networkx.pagerank, _pagerank_python, networkx.google_matrix)
+    )
     def test_zero_personalization_vector(self, alg):
         G = networkx.complete_graph(4)
         personalize = {0: 0, 1: 0, 2: 0, 3: 0}

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -55,28 +55,22 @@ class TestPageRank:
             )
         )
 
-    def test_pagerank(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_pagerank(self, alg):
         G = self.G
-        p = networkx.pagerank(G, alpha=0.9, tol=1.0e-08)
-        for n in G:
-            assert almost_equal(p[n], G.pagerank[n], places=4)
-        p = _pagerank_python(G, alpha=0.9, tol=1.0e-08)
+        p = alg(G, alpha=0.9, tol=1.0e-08)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
 
         nstart = {n: random.random() for n in G}
-        p = networkx.pagerank(G, alpha=0.9, tol=1.0e-08, nstart=nstart)
-        for n in G:
-            assert almost_equal(p[n], G.pagerank[n], places=4)
-        p = _pagerank_python(G, alpha=0.9, tol=1.0e-08)
+        p = alg(G, alpha=0.9, tol=1.0e-08, nstart=nstart)
         for n in G:
             assert almost_equal(p[n], G.pagerank[n], places=4)
 
-    def test_pagerank_max_iter(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_pagerank_max_iter(self, alg):
         with pytest.raises(networkx.PowerIterationFailedConvergence):
-            networkx.pagerank(self.G, max_iter=0)
-        with pytest.raises(networkx.PowerIterationFailedConvergence):
-            _pagerank_python(self.G, max_iter=0)
+            alg(self.G, max_iter=0)
 
     def test_numpy_pagerank(self):
         G = self.G
@@ -92,7 +86,10 @@ class TestPageRank:
         for (a, b) in zip(p, self.G.pagerank.values()):
             assert almost_equal(a, b)
 
-    def test_personalization(self):
+    @pytest.mark.parametrize(
+        "alg", (networkx.pagerank, _pagerank_python, networkx.pagerank_numpy)
+    )
+    def test_personalization(self, alg):
         G = networkx.complete_graph(4)
         personalize = {0: 1, 1: 1, 2: 4, 3: 4}
         answer = {
@@ -101,33 +98,18 @@ class TestPageRank:
             2: 0.267532673843324,
             3: 0.2675326738433241,
         }
-        p = networkx.pagerank(G, alpha=0.85, personalization=personalize)
-        for n in G:
-            assert almost_equal(p[n], answer[n], places=4)
-        p = _pagerank_python(G, alpha=0.85, personalization=personalize)
-        for n in G:
-            assert almost_equal(p[n], answer[n], places=4)
-        p = networkx.pagerank_numpy(G, alpha=0.85, personalization=personalize)
+        p = alg(G, alpha=0.85, personalization=personalize)
         for n in G:
             assert almost_equal(p[n], answer[n], places=4)
 
-    def test_zero_personalization_vector(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_zero_personalization_vector(self, alg):
         G = networkx.complete_graph(4)
         personalize = {0: 0, 1: 0, 2: 0, 3: 0}
-        pytest.raises(
-            ZeroDivisionError,
-            networkx.pagerank,
-            G,
-            personalization=personalize,
-        )
-        pytest.raises(
-            ZeroDivisionError,
-            _pagerank_python,
-            G,
-            personalization=personalize,
-        )
+        pytest.raises(ZeroDivisionError, alg, G, personalization=personalize)
 
-    def test_one_nonzero_personalization_value(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_one_nonzero_personalization_value(self, alg):
         G = networkx.complete_graph(4)
         personalize = {0: 0, 1: 0, 2: 0, 3: 1}
         answer = {
@@ -136,14 +118,12 @@ class TestPageRank:
             2: 0.22077931820379187,
             3: 0.3376620453886241,
         }
-        p = networkx.pagerank(G, alpha=0.85, personalization=personalize)
-        for n in G:
-            assert almost_equal(p[n], answer[n], places=4)
-        p = _pagerank_python(G, alpha=0.85, personalization=personalize)
+        p = alg(G, alpha=0.85, personalization=personalize)
         for n in G:
             assert almost_equal(p[n], answer[n], places=4)
 
-    def test_incomplete_personalization(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_incomplete_personalization(self, alg):
         G = networkx.complete_graph(4)
         personalize = {3: 1}
         answer = {
@@ -152,10 +132,7 @@ class TestPageRank:
             2: 0.22077931820379187,
             3: 0.3376620453886241,
         }
-        p = networkx.pagerank(G, alpha=0.85, personalization=personalize)
-        for n in G:
-            assert almost_equal(p[n], answer[n], places=4)
-        p = _pagerank_python(G, alpha=0.85, personalization=personalize)
+        p = alg(G, alpha=0.85, personalization=personalize)
         for n in G:
             assert almost_equal(p[n], answer[n], places=4)
 
@@ -178,16 +155,11 @@ class TestPageRank:
                 else:
                     assert almost_equal(M2[i, j], M1[i, j], places=4)
 
-    def test_dangling_pagerank(self):
-        pr = networkx.pagerank(self.G, dangling=self.dangling_edges)
-        for n in self.G:
-            assert almost_equal(pr[n], self.G.dangling_pagerank[n], places=4)
-        pr = _pagerank_python(self.G, dangling=self.dangling_edges)
-        for n in self.G:
-            assert almost_equal(pr[n], self.G.dangling_pagerank[n], places=4)
-
-    def test_dangling_numpy_pagerank(self):
-        pr = networkx.pagerank_numpy(self.G, dangling=self.dangling_edges)
+    @pytest.mark.parametrize(
+        "alg", (networkx.pagerank, _pagerank_python, networkx.pagerank_numpy)
+    )
+    def test_dangling_pagerank(self, alg):
+        pr = alg(self.G, dangling=self.dangling_edges)
         for n in self.G:
             assert almost_equal(pr[n], self.G.dangling_pagerank[n], places=4)
 
@@ -198,7 +170,8 @@ class TestPageRank:
         assert networkx.pagerank_numpy(G) == {}
         assert networkx.google_matrix(G).shape == (0, 0)
 
-    def test_multigraph(self):
+    @pytest.mark.parametrize("alg", (networkx.pagerank, _pagerank_python))
+    def test_multigraph(self, alg):
         G = networkx.MultiGraph()
         G.add_edges_from([(1, 2), (1, 2), (1, 2), (2, 3), (2, 3), ("3", 3), ("3", 3)])
         answer = {
@@ -207,10 +180,7 @@ class TestPageRank:
             3: 0.28933951385531687,
             "3": 0.16046911740146227,
         }
-        p = networkx.pagerank(G)
-        for n in G:
-            assert almost_equal(p[n], answer[n], places=4)
-        p = _pagerank_python(G)
+        p = alg(G)
         for n in G:
             assert almost_equal(p[n], answer[n], places=4)
 

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -70,6 +70,12 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="from_numpy_matrix"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="networkx.pagerank_numpy*"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="networkx.pagerank_scipy*"
+    )
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
A few suggestions related to the `DeprecationWarning` and the test suite - feel free to ignore/cherry-pick the commits you like. A quick summary:

### Deprecation Warning changes
 - fb3f862 adds `stacklevel=2` to the deprecation warnings. I think this necessary so that users using e.g. IPython or running scripts actually see the deprecation warning (this is the case on my system at least).
 - e9689d8 attempts to add a test for the above.
 - f5e5041 modifies `conftest.py` to suppress the (expected) deprecation warnings related to `pagerank_{numpy/scipy} and keep them out of the final warnings summary.

### Test suite
 - ac44bd7 parametrizes the tests on pagerank algorithm. IMO this is a really nice way of doing this because the `pagerank` and `_pagerank_python` should have the same signature, and parametrizing like this explicitly checks that.
 - 73bff76 expands one of the parametrizations to boost the module test coverage to 100%
