### PR TITLE
[Proposal] Rework the backend dispatching

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -3,6 +3,7 @@
 from collections import Counter
 from itertools import chain, combinations
 
+import networkx as nx
 from networkx.utils import not_implemented_for
 
 __all__ = [
@@ -218,6 +219,7 @@ def _directed_weighted_triangles_and_degree_iter(G, nodes=None, weight="weight")
         yield (i, dtotal, dbidirectional, directed_triangles)
 
 
+@nx.dispatch("average_clustering")
 def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     r"""Compute the average clustering coefficient for the graph G.
 
@@ -277,6 +279,7 @@ def average_clustering(G, nodes=None, weight=None, count_zeros=True):
     return sum(c) / len(c)
 
 
+@nx.dispatch("clustering")
 def clustering(G, nodes=None, weight=None):
     r"""Compute the clustering coefficient for nodes.
 
@@ -390,6 +393,7 @@ def clustering(G, nodes=None, weight=None):
     return clusterc
 
 
+@nx.dispatch("transitivity")
 def transitivity(G):
     r"""Compute graph transitivity, the fraction of all possible triangles
     present in G.
@@ -428,6 +432,7 @@ def transitivity(G):
     return 0 if triangles == 0 else triangles / contri
 
 
+@nx.dispatch("square_clustering")
 def square_clustering(G, nodes=None):
     r"""Compute the squares clustering coefficient for nodes.
 
@@ -505,6 +510,7 @@ def square_clustering(G, nodes=None):
     return clustering
 
 
+@nx.dispatch("generalized_degree")
 @not_implemented_for("directed")
 def generalized_degree(G, nodes=None):
     r"""Compute the generalized degree for nodes.

--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -378,6 +378,7 @@ def k_corona(G, k, core_number=None):
     return _core_subgraph(G, func, k, core_number)
 
 
+@nx.dispatch("k_truss")
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 def k_truss(G, k):

--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -5,7 +5,6 @@ import networkx as nx
 __all__ = ["hits"]
 
 
-@nx.dispatch("hits")
 def hits(G, max_iter=100, tol=1.0e-8, nstart=None, normalized=True):
     """Returns HITS hubs and authorities values for nodes.
 

--- a/networkx/algorithms/reciprocity.py
+++ b/networkx/algorithms/reciprocity.py
@@ -1,4 +1,5 @@
 """Algorithms to calculate reciprocity in a directed graph."""
+import networkx as nx
 from networkx import NetworkXError
 
 from ..utils import not_implemented_for
@@ -6,6 +7,7 @@ from ..utils import not_implemented_for
 __all__ = ["reciprocity", "overall_reciprocity"]
 
 
+@nx.dispatch("reciprocity")
 @not_implemented_for("undirected", "multigraph")
 def reciprocity(G, nodes=None):
     r"""Compute the reciprocity in a directed graph.
@@ -73,6 +75,7 @@ def _reciprocity_iter(G, nodes):
             yield (node, reciprocity)
 
 
+@nx.dispatch("overall_reciprocity")
 @not_implemented_for("undirected", "multigraph")
 def overall_reciprocity(G):
     """Compute the reciprocity for the whole graph.

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -1,6 +1,97 @@
-from dataclasses import dataclass
+"""
+Code to support various backends in a plugin dispatch architecture.
+
+Create a Dispatcher
+-------------------
+
+To be a valid plugin, a package must register an entry_point
+of `networkx.plugins` with a known key pointing to the handler.
+
+For example,
+```
+entry_points={'networkx.plugins': 'sparse = networkx_plugin_sparse'}
+```
+
+The plugin must create a Graph-like object which contains an attribute
+`__networkx_plugin__` with a value of the known key.
+
+Continuing the example above:
+```
+class WrappedSparse:
+    __networkx_plugin__ = "sparse"
+    ...
+```
+
+When a dispatchable networkx algorithm encounters a Graph-like object
+with a `__networkx_plugin__` attribute, it will look for the associated
+dispatch object in the entry_points, load it, and dispatch the work ot it.
+
+
+Testing
+-------
+To assist in validating the backend algorithm implementations, if an
+environment variable `NETWORKX_GRAPH_CONVERT` is set to one of the known
+plugin keys, the dispatch machinery will automatically convert regular
+networkx Graphs and DiGraphs to the backend equivalent by calling
+`<backend dispatcher>.convert(G, weight=weight)`.
+
+By defining a `convert` method and setting the environment variable,
+networkx will automatically route tests on dispatchable algorithms
+to the backend, allowing the full networkx test suite to be run against
+the backend implementation.
+
+Example pytest invocation:
+NETWORKX_GRAPH_CONVERT=sparse pytest --pyargs networkx
+
+The expectation is that each backend will pass all networkx tests
+to be considered a fully compliant backend.
+"""
+import os
+import sys
+import inspect
 from functools import wraps
 from importlib.metadata import entry_points
+
+
+__all__ = ["dispatch"]
+
+
+known_plugins = [
+    "sparse",  # scipy.sparse
+    "graphblas",  # python-graphblas
+    "cugraph",  # cugraph
+]
+
+
+class PluginInfo:
+    """Lazily loaded entry_points plugin information"""
+    def __init__(self):
+        self._items = None
+
+    def __bool__(self):
+        return len(self.items) > 0
+
+    @property
+    def items(self):
+        if self._items is None:
+            if sys.version_info < (3, 10):
+                self._items = entry_points()["networkx.plugins"]
+            else:
+                self._items = entry_points(group="networkx.plugins")
+        return self._items
+
+    def __contains__(self, name):
+        if sys.version_info < (3, 10):
+            return len([ep for ep in self.items if ep.name == name]) > 0
+        return name in self.items.names
+
+    def __getitem__(self, name):
+        if sys.version_info < (3, 10):
+            return [ep for ep in self.items if ep.name == name][0]
+        return self.items[name]
+
+
+plugins = PluginInfo()
 
 
 def dispatch(algo):
@@ -8,11 +99,12 @@ def dispatch(algo):
         @wraps(func)
         def wrapper(*args, **kwds):
             graph = args[0]
-            plugins = entry_points(group="networkx.plugins")
-            if isinstance(graph, WrappedGraph) and plugins:
-                if isinstance(graph, WrappedSparse) and "sparse" in plugins.names:
-                    backend = plugins["sparse"].load()
-                    return getattr(backend, algo).__call__(*args, **kwds)
+            if hasattr(graph, "__networkx_plugin__") and plugins:
+                plugin_name = graph.__networkx_plugin__
+                if plugin_name in plugins:
+                    backend = plugins[plugin_name].load()
+                    if hasattr(backend, algo):
+                        return getattr(backend, algo).__call__(*args, **kwds)
             return func(*args, **kwds)
 
         return wrapper
@@ -20,12 +112,31 @@ def dispatch(algo):
     return algorithm
 
 
-@dataclass
-class WrappedGraph:
-    ...
+# Override `dispatch` for testing
+if os.environ.get("NETWORKX_GRAPH_CONVERT"):
+    plugin_name = os.environ["NETWORKX_GRAPH_CONVERT"]
+    if plugin_name not in known_plugins:
+        raise Exception(f"{plugin_name} is not a known plugin; must be one of {known_plugins}")
+    if not plugins:
+        raise Exception("No registered networkx.plugins entry_points")
+    if plugin_name not in plugins:
+        raise Exception(f"No registered networkx.plugins entry_point named {plugin_name}")
 
+    def dispatch(algo):
+        def algorithm(func):
+            sig = inspect.signature(func)
 
-@dataclass
-class WrappedSparse(WrappedGraph):
-    sparse_array: ...
-    nodelist: list
+            @wraps(func)
+            def wrapper(*args, **kwds):
+                backend = plugins[plugin_name].load()
+                bound = sig.bind(*args, **kwds)
+                bound.apply_defaults()
+                graph, *args = args
+                # Convert graph into backend graph-like object
+                #   Include the weight label, if provided to the algorithm
+                graph = backend.convert(graph, bound.arguments.get("weight"))
+                return getattr(backend, algo).__call__(graph, *args, **kwds)
+
+            return wrapper
+
+        return algorithm


### PR DESCRIPTION
- Use __networkx_plugin__=name to find graph-like objects instead of
  subclassing
- Add PluginInfo to smooth over differences in importlib.metadata across
  python versions
- Add dispatch behavior override via environment variable to aid in
  testing plugins
