### PR TITLE
Make convert to and from methods for auto-testing

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 
+@nx._dispatch
 def has_path(G, source, target):
     """Returns *True* if *G* has a path from *source* to *target*.
 

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -5,7 +5,7 @@ Create a Dispatcher
 -------------------
 
 To be a valid plugin, a package must register an entry_point
-of `networkx.plugins` with a known key pointing to the handler.
+of `networkx.plugins` with a key pointing to the handler.
 
 For example,
 ```
@@ -13,7 +13,7 @@ entry_points={'networkx.plugins': 'sparse = networkx_plugin_sparse'}
 ```
 
 The plugin must create a Graph-like object which contains an attribute
-`__networkx_plugin__` with a value of the known key.
+`__networkx_plugin__` with a value of the entry point name.
 
 Continuing the example above:
 ```
@@ -30,7 +30,7 @@ dispatch object in the entry_points, load it, and dispatch the work to it.
 Testing
 -------
 To assist in validating the backend algorithm implementations, if an
-environment variable `NETWORKX_GRAPH_CONVERT` is set to one of the known
+environment variable `NETWORKX_GRAPH_CONVERT` is set to a registered
 plugin keys, the dispatch machinery will automatically convert regular
 networkx Graphs and DiGraphs to the backend equivalent by calling
 `<backend dispatcher>.convert_from_nx(G, weight=weight, name=name)`.
@@ -66,13 +66,6 @@ from importlib.metadata import entry_points
 from ..exception import NetworkXNotImplemented
 
 __all__ = ["_dispatch", "_mark_tests"]
-
-
-known_plugins = [
-    "sparse",  # scipy.sparse
-    "graphblas",  # python-graphblas
-    "cugraph",  # cugraph
-]
 
 
 class PluginInfo:
@@ -202,10 +195,6 @@ def test_override_dispatch(func=None, *, name=None):
 # pytest.
 if os.environ.get("NETWORKX_GRAPH_CONVERT"):
     plugin_name = os.environ["NETWORKX_GRAPH_CONVERT"]
-    if plugin_name not in known_plugins:
-        raise Exception(
-            f"{plugin_name} is not a known plugin; must be one of {known_plugins}"
-        )
     if not plugins:
         raise Exception("No registered networkx.plugins entry_points")
     if plugin_name not in plugins:

--- a/networkx/classes/backends.py
+++ b/networkx/classes/backends.py
@@ -33,12 +33,12 @@ To assist in validating the backend algorithm implementations, if an
 environment variable `NETWORKX_GRAPH_CONVERT` is set to one of the known
 plugin keys, the dispatch machinery will automatically convert regular
 networkx Graphs and DiGraphs to the backend equivalent by calling
-`<backend dispatcher>.convert_from_nx(G, weight=weight)`.
+`<backend dispatcher>.convert_from_nx(G, weight=weight, name=name)`.
 
 The converted object is then passed to the backend implementation of
 the algorithm. The result is then passed to
-`<backend dispatcher>.convert_to_nx(result)` to convert back to a form
-expected by the NetworkX tests.
+`<backend dispatcher>.convert_to_nx(result, name=name)` to convert back
+to a form expected by the NetworkX tests.
 
 By defining `convert_from_nx` and `convert_to_nx` methods and setting
 the environment variable, NetworkX will automatically route tests on
@@ -187,9 +187,9 @@ def test_override_dispatch(func=None, *, name=None):
                 weight = bound.arguments["data"]
             elif bound.arguments["data"]:
                 weight = "weight"
-        graph = backend.convert_from_nx(graph, weight=weight)
+        graph = backend.convert_from_nx(graph, weight=weight, name=name)
         result = getattr(backend, name).__call__(graph, *args, **kwds)
-        return backend.convert_to_nx(result)
+        return backend.convert_to_nx(result, name=name)
 
     _register_algo(name, wrapper)
     return wrapper


### PR DESCRIPTION
- Rename `convert` to `convert_from_nx`
- Add `convert_to_nx` function

These will allow backends to return native objects when dispatching, but provide a mechanism to convert the result to the type expected by NetworkX tests for the auto-test plugin mechanism.

<!--
Please run black to format your code.
See https://networkx.org/documentation/latest/developer/contribute.html for details.
-->
